### PR TITLE
feat!: added parsing for radical indicators ("*")

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,5 @@
-export type RootComponent = {
-  c: string;
-  var?: string;
-  sub?: Array<SubComponent>;
-};
-export type SubComponent = { c: string; var?: string };
+export type BaseComponent = { c: string; var?: string; is_rad?: true };
+export type RootComponent = BaseComponent & { sub?: Array<BaseComponent> };
 export type Components = Array<RootComponent>;
 
 export { parse } from './parse.js';

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -46,6 +46,22 @@ describe('parse function', () => {
     ]);
   });
 
+  test('parses a radical indicator', () => {
+    const result = parse('前[丷㇐⽉⺉]⼑*');
+    expect(result).toEqual([
+      { c: '前', sub: [{ c: '丷' }, { c: '㇐' }, { c: '⽉' }, { c: '⺉' }] },
+      { c: '⼑', is_rad: true },
+    ]);
+  });
+
+  test('parses a radical indicator in a sub-component', () => {
+    const result = parse('⼝{030-hen}兄[⼝*⼉]');
+    expect(result).toEqual([
+      { c: '⼝', var: '030-hen' },
+      { c: '兄', sub: [{ c: '⼝', is_rad: true }, { c: '⼉' }] },
+    ]);
+  });
+
   test('handles non-BMP characters', () => {
     const result = parse('𠮷{056-kanmuri}[⼠⼝]');
     expect(result).toEqual([
@@ -53,16 +69,25 @@ describe('parse function', () => {
     ]);
   });
 
-  test('throws error on invalid variant format', () => {
+  test('throws on invalid variant format', () => {
     expect(() => parse('⼁{30}')).toThrow('Invalid variant format');
   });
 
-  test('throws error on unclosed subcomponent bracket', () => {
+  test('throws on unclosed subcomponent bracket', () => {
     expect(() => parse('⼁[⼠⼝')).toThrow('Unclosed subcomponent bracket');
     expect(() => parse('⼁[')).toThrow('Unclosed subcomponent bracket');
   });
 
-  test('handles empty string', () => {
+  test('throws on invalid placement of radical indicator', () => {
+    expect(() => parse('⼝{030-hen}*兄[⼝⼉]')).toThrow(
+      'Invalid radical indicator'
+    );
+    expect(() => parse('⼝{030-hen}兄[⼝⼉]*')).toThrow(
+      'Invalid radical indicator'
+    );
+  });
+
+  test('handles an empty string', () => {
     const result = parse('');
     expect(result).toEqual([]);
   });

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,25 +1,17 @@
-import type { Components, RootComponent, SubComponent } from './index.js';
+import type { Components, BaseComponent, RootComponent } from './index.js';
 
 export function parse(input: string): Components {
   const components: Components = [];
   let rest = input;
 
   while (rest.length > 0) {
-    const c = [...rest][0]!;
-    rest = rest.slice(c.length);
-
-    const component: RootComponent = { c };
-
-    if (rest[0] === '{') {
-      const { variant, rest: newRest } = parseVariant(rest);
-      component.var = variant;
-      rest = newRest;
-    }
+    let component: RootComponent;
+    ({ component, rest } = consumeComponent(rest));
 
     if (rest[0] === '[') {
-      const { subComponents, rest: newRest } = parseSubComponents(rest);
+      let subComponents: Array<BaseComponent>;
+      ({ subComponents, rest } = consumeSubComponents(rest));
       component.sub = subComponents;
-      rest = newRest;
     }
 
     components.push(component);
@@ -28,7 +20,33 @@ export function parse(input: string): Components {
   return components;
 }
 
-function parseVariant(input: string): { variant: string; rest: string } {
+function consumeComponent(input: string): {
+  component: BaseComponent;
+  rest: string;
+} {
+  const c = String.fromCodePoint(input.codePointAt(0)!);
+  if (c === '*') {
+    throw new Error('Invalid radical indicator');
+  }
+  let component: BaseComponent = { c };
+
+  let rest = input.slice(c.length);
+
+  if (rest[0] === '*') {
+    component.is_rad = true;
+    rest = rest.slice(1);
+  }
+
+  if (rest[0] === '{') {
+    let variant: string;
+    ({ variant, rest } = consumeVariant(rest));
+    component.var = variant;
+  }
+
+  return { component, rest };
+}
+
+function consumeVariant(input: string): { variant: string; rest: string } {
   const match = input.match(/^\{(\d{3}(?:-[a-z0-9]+)?)\}(.*)/s);
   if (!match) {
     throw new Error(`Invalid variant format: ${input}`);
@@ -36,11 +54,11 @@ function parseVariant(input: string): { variant: string; rest: string } {
   return { variant: match[1]!, rest: match[2]! };
 }
 
-function parseSubComponents(input: string): {
-  subComponents: SubComponent[];
+function consumeSubComponents(input: string): {
+  subComponents: BaseComponent[];
   rest: string;
 } {
-  const subComponents: SubComponent[] = [];
+  const subComponents: Array<BaseComponent> = [];
   let rest = input.slice(1); // Remove opening '['
 
   if (rest.length === 0) {
@@ -48,16 +66,9 @@ function parseSubComponents(input: string): {
   }
 
   while (rest[0] !== ']') {
-    const c = [...rest][0]!;
-    rest = rest.slice(c.length);
-
-    if (rest[0] === '{') {
-      const { variant, rest: newRest } = parseVariant(rest);
-      subComponents.push({ c, var: variant });
-      rest = newRest;
-    } else {
-      subComponents.push({ c });
-    }
+    let component: BaseComponent;
+    ({ component, rest } = consumeComponent(rest));
+    subComponents.push(component);
 
     if (rest.length === 0) {
       throw new Error('Unclosed subcomponent bracket');

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,4 +1,4 @@
-import type { Components, RootComponent, SubComponent } from './index.js';
+import type { BaseComponent, Components, RootComponent } from './index.js';
 
 export function serialize(components: Components): string {
   return components.map(serializeComponent).join('');
@@ -6,6 +6,9 @@ export function serialize(components: Components): string {
 
 function serializeComponent(component: RootComponent): string {
   let result = component.c;
+  if (component.is_rad) {
+    result += '*';
+  }
   if (component.var) {
     result += `{${component.var}}`;
   }
@@ -15,8 +18,11 @@ function serializeComponent(component: RootComponent): string {
   return result;
 }
 
-function serializeSubComponent(component: SubComponent): string {
+function serializeSubComponent(component: BaseComponent): string {
   let result = component.c;
+  if (component.is_rad) {
+    result += '*';
+  }
   if (component.var) {
     result += `{${component.var}}`;
   }


### PR DESCRIPTION
The component type is extended with an optional field, `is_rad`, which
indicates a component is the radical for this character.

In general the first component that matches the kanji radical is
presumed to be the radical component. However, in some cases
disambiguation is required such as 剪 where ⼑ is the radical, not ⺉.

BREAKING CHANGE: The "*" character is now treated as a special character
meaning "the preceding component is the radical for this character".

BREAKING CHANGE: The `SubComponent` type is now called `BaseComponent`.
